### PR TITLE
Fix 'sys/resource.h' not included in hypervisor.cpp

### DIFF
--- a/hypervisor.cpp
+++ b/hypervisor.cpp
@@ -21,6 +21,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/time.h>
+#include <sys/resource.h>
 #include <sys/wait.h>
 #include <fcntl.h>
 #include <signal.h>


### PR DESCRIPTION
My system wasn't able to build telling that `struct rusage` had incomplete type
